### PR TITLE
Uproszczenie linków między wpisami

### DIFF
--- a/_posts/2025-03-24-zajawka-topiel.md
+++ b/_posts/2025-03-24-zajawka-topiel.md
@@ -31,7 +31,7 @@ Mając to wszystko na uwadze, "*Topiel*" polecam jako odprężającą lekturę z
 ## Warto przeczytać również
 
 1. **Łukasz Orbitowski - "*Inna Dusza*"**: jeżeli ktoś po przeczytaniu "*Topieli*" poczuje, że chce jeszcze większą dawkę nostalgii lat 90., to "*Inna Dusza*" Orbitowskiego zdecydowanie ją zapewni.
-2. [**Arnold Cytrowski - "*Anhedonia*"**]({{ site.baseurl }}{% link _posts/2025-02-24-zajawka-anhedonia.md %}): znowu lata 90, choć w bardziej surowym klimacie światka gangsterskiego. Tu również pojawia się wątek powodzi tysiąclecia.
+2. [**Arnold Cytrowski - "*Anhedonia*"**]({% post_url 2025-02-24-zajawka-anhedonia.md %}): znowu lata 90, choć w bardziej surowym klimacie światka gangsterskiego. Tu również pojawia się wątek powodzi tysiąclecia.
 3. **Piotr Adamczyk - "*Dom tęsknot*"**: historia nostalgiczna w zupełnie inny sposób, warta uwagi pod kątem portretu psychologicznego głównego bohatera.
 4. **Jerome David Salinger - "*Buszujący w zbożu*"**: nie potrafię wyjaśnić dlaczego, ale odczuwam jakieś subtelne powiązanie "*Topieli*" z "*Buszującym w zbożu*".
 

--- a/_posts/2025-03-29-zajawka-dlugie-pozegnanie.md
+++ b/_posts/2025-03-29-zajawka-dlugie-pozegnanie.md
@@ -35,7 +35,7 @@ Dlatego "*Długie pożegnanie*" polecam dwóm grupom czytelników. Pierwsza: mi�
 1. **Raymond Chandler - "*Tajemnica jeziora*"**: prawdopodobnie najbardziej przystępna i wciągająca część z serii o przygodach detektywa Marlowe'a. Intrygi, niewyjaśnione okoliczności i nowobogaccy.
 2. **Raymond Chandler - "*Siostrzyczka*"**: w tej części przygód Marlowe'a język był najbardziej cięty, Marlowe najbardziej arogancki, a fabuła najbardziej pogmatwana. Może dlatego pamiętam ją jako najlepszą z serii?
 3. **Francis Scott Fitzgerald - "*Wielki Gatsby*"**: gdy mówię o "czytelnikach ceniących refleksje na temat zmagań uczciwego człowieka z nieuczciwym światem", mam na myśli tego typu książki.
-4. [**Arnold Cytrowski - "*Anhedonia*"**]({{ site.baseurl }}{% link _posts/2025-02-24-zajawka-anhedonia.md %}): jak skojarzyć "Anhedonię" z książkami Chandlera? Słowo klucz: *noir*. Inne czasy, zupełnie inna historia, a klimat zdaje się podobny.
+4. [**Arnold Cytrowski - "*Anhedonia*"**]({% post_url 2025-02-24-zajawka-anhedonia.md %}): jak skojarzyć "Anhedonię" z książkami Chandlera? Słowo klucz: *noir*. Inne czasy, zupełnie inna historia, a klimat zdaje się podobny.
 5. **Sławek Gortych - "*Schronisko, które spowijał mrok*"**: może nie noir, ale ta konkretna historia kryminalna ma w sobie coś z klasyków detektywistycznych.
 
 ## Dodatkowe linki

--- a/_posts/2025-04-02-zajawka-paradyzja.md
+++ b/_posts/2025-04-02-zajawka-paradyzja.md
@@ -36,7 +36,7 @@ Bez wahania polecam tę książkę każdemu. Da się ją przeczytać w jedno 
 2. **Brian Aldis - "*Non Stop*"**: w "*Non Stop*" pojawia się trochę wątków zbieżnych z "*Paradyzją*", a że to też dobra lektura, to polecam jako uzupełnienie.
 3. **Edward Snowden - "*Pamięć nieulotna*"**: jeżeli ktoś *nie wierzy w tą całą masową inwigilację*, to ta książka Snowdena pozwoli mu wyjść spod kamienia.
 4. **Jarosław Królewski, Krzysztof Rybiński - "*Algokracja*"**: to z tej książki dowiedziałem się o wielu zagadnieniach związanych ze sztuczną inteligencją, w tym także o *scoringu* społecznym w Chinach. Książka raczej z tych bezkrytycznie promujących wykorzystanie AI, ale ciekawie było poznać perspektywę entuzjastów tej technologii.
-5. [**Krzysztof Wosiński - "*OSINT: Nowy wymiar poszukiwań w sieci*"**]({{ site.baseurl }}{% link _posts/2025-03-16-zajawka-osint.md %}): to tak, jakby ktoś chciał się przekonać, ile informacji na swój temat jest w stanie znaleźć w sieci.
+5. [**Krzysztof Wosiński - "*OSINT: Nowy wymiar poszukiwań w sieci*"**]({% post_url 2025-03-16-zajawka-osint.md %}): to tak, jakby ktoś chciał się przekonać, ile informacji na swój temat jest w stanie znaleźć w sieci.
 
 ## Dodatkowe linki
 

--- a/_posts/2025-04-23-chris-hogan-everyday-millionaires.md
+++ b/_posts/2025-04-23-chris-hogan-everyday-millionaires.md
@@ -33,7 +33,7 @@ Podsumowując: Hogan napisał książkę na podstawie badania, którego w niej n
 1. **Joe Dominguez, Vicki Robin - "*Your Money or Your Life*"**: książka również o filozofii oszczędzania (i nie tylko), która jest może i nieco bardziej dogmatyczna, ale też niesie za sobą więcej praktycznych wskazówek. Kto wie, może spora część grupy w badaniu Hogana też to czytała?
 2. **Mateusz Samołyk - "*Inwestowanie dla każdego*"**: bardzo dobry przewodnik po świecie inwestowania, w którym książka "*Everyday Millionaires*" jest osadzona w tle i przez to wybrzmiewa dużo bardziej.
 3. **Marcin Iwuć - "*Finansowa Forteca*"**: podstawowa lektura dla każdego, kto próbuje wejść do świata inwestowania w polskich realiach.
-4. [**Michał Szafrański - "*Finansowy Ninja*"**]({{ site.baseurl }}{% link _posts/2025-02-04-zajawka_finansowy_ninja.md %}): jeżeli jakaś polska książka zawiera w sobie streszczenie "*Everyday Millionaires*", to właśnie ta.
+4. [**Michał Szafrański - "*Finansowy Ninja*"**]({% post_url 2025-02-04-zajawka_finansowy_ninja.md %}): jeżeli jakaś polska książka zawiera w sobie streszczenie "*Everyday Millionaires*", to właśnie ta.
 5. **Ramit Sethi - "*I will teach you to be rich*"**: pragmatyczny, amerykański poradnik o finansach osobistych.
 
 ## Dodatkowe linki

--- a/_posts/2025-05-07-lukasz-orbitowski-exodus.md
+++ b/_posts/2025-05-07-lukasz-orbitowski-exodus.md
@@ -33,8 +33,8 @@ Biorąc to wszystko pod uwagę, "*Exodus*" polecam głównie dwóm grupom: fanom
 ## Warto przeczytać również
 
 1. **Łukasz Orbitowski - "*Inna dusza*"**: inna powieść Orbitowskiego z silnym naciskiem na portrety psychologiczne.
-2. [**Arnold Cytrowski - "*Anhedonia*"**]({{ site.baseurl }}{% link _posts/2025-02-24-zajawka-anhedonia.md %}): retrospektywy, portrety psychologiczne, ciąg nieprzewidywalnych wydarzeń - to zbieżności między "*Anhedonią*" i "*Exodusem*".
-3. [**Dmitry Glukhovsky - "*Tekst*"**]({{ site.baseurl }}{% link _posts/2025-02-19-zajawka-tekst.md %}): wątek mierzenia się z przeszłością Głuchowski przedstawia zupełnie inaczej, ale i tak "*Exodus*" budzi we mnie luźne skojarzenie z tą książką.
+2. [**Arnold Cytrowski - "*Anhedonia*"**]({% post_url 2025-02-24-zajawka-anhedonia.md %}): retrospektywy, portrety psychologiczne, ciąg nieprzewidywalnych wydarzeń - to zbieżności między "*Anhedonią*" i "*Exodusem*".
+3. [**Dmitry Glukhovsky - "*Tekst*"**]({% post_url 2025-02-19-zajawka-tekst.md %}): wątek mierzenia się z przeszłością Głuchowski przedstawia zupełnie inaczej, ale i tak "*Exodus*" budzi we mnie luźne skojarzenie z tą książką.
 4. **Piotr Adamczyk - "*Dom tęsknot*"**: kolejne bardzo luźne skojarzenie - tym razem książka skupiona głównie na retrospektywie, która wyjaśnia bieżącą sytuację głównego bohatera, co jest w zasadzie odwrotnością fabuły "*Exodusu*".
 5. **Malcolm XD - "*Emigracja*"**: memiczna powieść o emigracji - czyli wątek luźno zbieżny z tym, co pojawia się w "*Exodusie*".
 

--- a/_posts/2025-05-17-raymond-chandler-playback.md
+++ b/_posts/2025-05-17-raymond-chandler-playback.md
@@ -26,7 +26,7 @@ To wszystko z pozoru buduje wciągającą intrygę, jednak "*Playback*" ma kilka
 
 Przede wszystkim, brakuje tu tak ostrego języka jak na przykład w "*Siostrzyczce*". Może to wina tłumaczenia, jednak stylistyka noir i cynizm w dialogach są tu stonowane, więc podczas czytania brakuje spontanicznych parsknięć śmiechem wywołanych trafnymi opisami. Pojawiają się natomiast aż trzy wątki romantyczne, które, moim zdaniem, nic nie wnoszą.
 
-Gdy opisywałem ["*Długie pożegnanie*"]({{ site.baseurl }}{% link _posts/2025-03-29-zajawka-dlugie-pozegnanie.md %}), wspomniałem o patetyczności. W "*Playbacku*" reguły, którymi kieruje się Marlowe, są na pierwszym planie i okazuje się, że wcale nie wypada to najlepiej. Detektyw wmieszany w sprawę z zabójstwem w tle raz przyjmuje, a raz oddaje pieniądze zleceniodawcom - zależnie od tego, czy czuje się z nimi dobrze, czy nie - co wypada dość nierealistycznie.
+Gdy opisywałem ["*Długie pożegnanie*"]({% post_url 2025-03-29-zajawka-dlugie-pozegnanie.md %}), wspomniałem o patetyczności. W "*Playbacku*" reguły, którymi kieruje się Marlowe, są na pierwszym planie i okazuje się, że wcale nie wypada to najlepiej. Detektyw wmieszany w sprawę z zabójstwem w tle raz przyjmuje, a raz oddaje pieniądze zleceniodawcom - zależnie od tego, czy czuje się z nimi dobrze, czy nie - co wypada dość nierealistycznie.
 
 Mając na uwadze to wszystko, nie mogę jednak powiedzieć, że "*Playback*" to zła książka. Jest po prostu średnia. Nie porwała mnie, choć też nie odpychała. Zakończenie serii w tej książce było dobrym posunięciem i autor zrobił to w sposób jednoznaczny. Niemniej, poczytałbym jeszcze coś o przygodach tego detektywa alkoholika z Los Angeles...
 
@@ -34,7 +34,7 @@ Mając na uwadze to wszystko, nie mogę jednak powiedzieć, że "*Playback*" to 
 
 1. **Raymond Chandler - "*Głęboki sen*"**: pierwsza część przygód Marlowe'a nadała serii pewnego kolorytu, który potem był podtrzymywany w różnym stopniu.
 2. **Raymond Chandler - "*Siostrzyczka*"**: jeżeli gdzieś Chandler wszedł na wyżyny sarkazmu, to właśnie w tej części z serii.
-3. [**Walter Mosley - "*Diabeł w błękitnej sukience*"**]({{ site.baseurl }}{% link _posts/2025-04-24-walter-mosley-diabel-w-blekitnej-sukience.md %}): zupełnie inna książka w nieco innych realiach, bo głównym bohaterem jest czarnoskóry weteran drugiej wojny światowej. Nieco bardziej wciągająca niż "*Playback*" między innymi ze względu na rzut okiem na inne tło historyczne.
+3. [**Walter Mosley - "*Diabeł w błękitnej sukience*"**]({% post_url 2025-04-24-walter-mosley-diabel-w-blekitnej-sukience.md %}): zupełnie inna książka w nieco innych realiach, bo głównym bohaterem jest czarnoskóry weteran drugiej wojny światowej. Nieco bardziej wciągająca niż "*Playback*" między innymi ze względu na rzut okiem na inne tło historyczne.
 
 ## Dodatkowe linki
 

--- a/_posts/2025-05-21-raymond-chandler-klopoty-to-moja-specjalnosc.md
+++ b/_posts/2025-05-21-raymond-chandler-klopoty-to-moja-specjalnosc.md
@@ -22,9 +22,9 @@ Marlowe próbuje na zlecenie milionera zniszczyć związek młodego dziedzica. M
 
 Te przedstawione wyżej cztery opowiadania to intrygujące historie, które przyjemnie się czyta. Krótka forma nie pozwala tu na przesadne rozbudowywanie wątków, więc czytelnik dostaje cztery przystępne utwory literackie. Każdy z nich ma relatywnie proste rozwiązanie, choć zaskakujące w sposób nieoczywisty.
 
-[Wspomniałem ostatnio o tym, że Marlowe to detektyw-alkoholik]({{ site.baseurl }}{% link _posts/2025-05-17-raymond-chandler-playback.md %}). W opowiadaniach rzuca się to w oczy jeszcze bardziej. Główny bohater zdaje się w ogóle nie trzeźwieć. Z perspektywy współczesnej podważa to trochę jego profesjonalizm, choć podejrzewam, że w latach 50. XX wieku mogło to być nieco bardziej akceptowalne społecznie. Tak czy inaczej, śledzenie ilości przelewającej się w tych opowiadaniach whiskey było dla mnie pewnym *guilty pleasure*.
+[Wspomniałem ostatnio o tym, że Marlowe to detektyw-alkoholik]({% post_url 2025-05-17-raymond-chandler-playback.md %}). W opowiadaniach rzuca się to w oczy jeszcze bardziej. Główny bohater zdaje się w ogóle nie trzeźwieć. Z perspektywy współczesnej podważa to trochę jego profesjonalizm, choć podejrzewam, że w latach 50. XX wieku mogło to być nieco bardziej akceptowalne społecznie. Tak czy inaczej, śledzenie ilości przelewającej się w tych opowiadaniach whiskey było dla mnie pewnym *guilty pleasure*.
 
-Widać także, że język w tej książce jest nieco bardziej kąśliwy niż w ["*Playbacku*"]({{ site.baseurl }}{% link _posts/2025-05-17-raymond-chandler-playback.md %}) (zaznaczę: nie potrafię oszacować roli tłumacza). Marlowe jest cyniczny w bardziej wiarygodny sposób, a opisy często trafne, albo przynajmniej na swój sposób zabawne. To zdecydowany plus tej lektury.
+Widać także, że język w tej książce jest nieco bardziej kąśliwy niż w ["*Playbacku*"]({% post_url 2025-05-17-raymond-chandler-playback.md %}) (zaznaczę: nie potrafię oszacować roli tłumacza). Marlowe jest cyniczny w bardziej wiarygodny sposób, a opisy często trafne, albo przynajmniej na swój sposób zabawne. To zdecydowany plus tej lektury.
 
 Podsumowując, polecam ten zbiór opowiadań głównie fanom powieści detektywistycznych. Osoby niezaznajomione z twórczością Chandlera mogą śmiało traktować tę pozycję jako wstęp do przygód Marlowe'a, zwłaszcza że opowiadania są niejako prequelem powieści. Sugerowałbym jednak nie nastawiać się na historie z przekazem. To czysta rozrywka, osadzona w latach 50. i obleczona w ironiczne opisy. Nie widzę tu innych, głębszych powodów do sięgania po tę książkę, jednak te już wspomniane powinny być wystarczające.
 
@@ -32,7 +32,7 @@ Podsumowując, polecam ten zbiór opowiadań głównie fanom powieści detektywi
 
 1. **Raymond Chandler - "*Głęboki sen*"**: pierwsza powieść z cyklu o detektywie Marlowe.
 2. **Raymond Chandler - "*Siostrzyczka*"**: moim zdaniem najlepsza część z cyklu o detektywie Marlowe.
-3. [**Walter Mosley - "*Diabeł w błękitnej sukience*"**]({{ site.baseurl }}{% link _posts/2025-04-24-walter-mosley-diabel-w-blekitnej-sukience.md %}): również noir z podobnego okresu, choć nie stricte o detektywach.
+3. [**Walter Mosley - "*Diabeł w błękitnej sukience*"**]({% post_url 2025-04-24-walter-mosley-diabel-w-blekitnej-sukience.md %}): również noir z podobnego okresu, choć nie stricte o detektywach.
 
 ## Dodatkowe linki
 

--- a/_posts/2025-06-02-festinger-riecken-schachter-when-prophecy-fails.md
+++ b/_posts/2025-06-02-festinger-riecken-schachter-when-prophecy-fails.md
@@ -33,7 +33,7 @@ Można mieć zastrzeżenia dotyczące etyki badania. Do metodologii badacze odni
 1. **Daniel Kanheman - "*Pułapki Myślenia*"**: ta bestsellerowa książka omawia temat błędów poznawczych bardzo przekrojowo i moim zdaniem stanowi świetny wstęp do tematyki. W kontekście "*When Prophecy Fails*", warto przeczytać u Kahnemana o tzw. *utopionych kosztach*.
 2. **Adam Grant - "*Leniwy Umysł*"**: Grant w pragmatyczny sposób odniósł się do ciągłej walidacji swoich poglądów i choć uważam, że polski tytuł w ogóle nie oddaje clou tej lektury, to jest ona zdecydowanie warta uwagi.
 3. **Annie Duke - "*Quit*"**: to książka o tym, jak rezygnować z różnych rzeczy. Zwłaszcza z tych, które niosą za sobą przede wszystkim negatywne skutki.
-4. **[Garrett M. Graff - "*UFO*"]({{ site.baseurl }}{% link _posts/2025-03-10-zajawka-ufo.md %})**: z nieco innej beczki, ta książka pokazuje jak w czasach analizowanego kultu wyglądała popularność latających spodków.
+4. **[Garrett M. Graff - "*UFO*"]({% post_url 2025-03-10-zajawka-ufo.md %})**: z nieco innej beczki, ta książka pokazuje jak w czasach analizowanego kultu wyglądała popularność latających spodków.
 5. **Nassim Nicholas Taleb - "*Czarny Łabędź*"**: to książka o tym, dlaczego ogólnie jesteśmy słabi w prognozowanie czegokolwiek.
 
 ## Dodatkowe linki

--- a/_posts/2025-06-16-zajawka-szeptuchy.md
+++ b/_posts/2025-06-16-zajawka-szeptuchy.md
@@ -34,7 +34,7 @@ Choć miejscami lektura bywała nużąca, uważam, że była warta uwagi. Pokazu
 
 ## Warto przeczytać również
 
-1. [**Anna Romaniuk - "*Orzeszkowo 14. Historie z Podlasia*"**]({{ site.baseurl }}{% link _posts/2025-06-07-zajawka-orzeszkowo-14.md %}): zbiór esejów o okolicach Hajnówki, który dość dobrze wprowadza w kontekst regionu.
+1. [**Anna Romaniuk - "*Orzeszkowo 14. Historie z Podlasia*"**]({% post_url 2025-06-07-zajawka-orzeszkowo-14.md %}): zbiór esejów o okolicach Hajnówki, który dość dobrze wprowadza w kontekst regionu.
 2. **Aneta Prymaka-Oniszk** - "*Kamienie musiały polecieć*": reportaż Wydawnictwa Czarnego na temat Podlasia, który pokazuje burzliwą przeszłość regionu z perspektywy ludności prawosławnej.
 3. **Kamil Janicki - "*Cywilizacja Słowian*"**: szerszy kontekst słowiańskich wierzeń ludowych, odarty z legend i dopisanych współcześnie uzupełnień.
 


### PR DESCRIPTION
## Nowości

Brak.

## Ulepszenia

Uproszczone linki między wpisami za pomocą [`post_url`](https://jekyllrb.com/docs/liquid/tags/#linking-to-posts)

## Poprawki

Brak.